### PR TITLE
fix: remove redundant fee bounds check in forwarder contract

### DIFF
--- a/factory/src/lib.rs
+++ b/factory/src/lib.rs
@@ -14,7 +14,7 @@ const STORAGE_BALANCE_BOUND: NearToken = NearToken::from_yoctonear(1_250_000_000
 const FORWARDER_NEW_GAS: Gas = Gas::from_tgas(2);
 
 pub const MAX_NUM_CONTRACTS: usize = 12;
-pub const INIT_BALANCE: NearToken = NearToken::from_millinear(360);
+pub const INIT_BALANCE: NearToken = NearToken::from_millinear(355);
 
 #[near_bindgen]
 #[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]

--- a/forwarder/src/lib.rs
+++ b/forwarder/src/lib.rs
@@ -24,9 +24,8 @@ mod types;
 #[global_allocator]
 static ALLOCATOR: NoopAllocator = NoopAllocator;
 
-const MINIMUM_BALANCE: u128 = 360_000_000_000_000_000_000_000;
+const MINIMUM_BALANCE: u128 = 355_000_000_000_000_000_000_000;
 const ZERO_YOCTO: u128 = 0;
-const MAX_FEE_PERCENT: u128 = 10;
 
 const CALCULATE_FEES_GAS: u64 = 4_000_000_000_000;
 const NEAR_DEPOSIT_GAS: u64 = 2_000_000_000_000;
@@ -155,10 +154,6 @@ pub extern "C" fn finish_forward_callback() {
         _ => panic_utf8(b"FEE RESULT IS NOT READY"),
     };
 
-    if !is_fee_allowed(params.amount, fee) {
-        panic_utf8(b"FEE IS TOO BIG");
-    }
-
     let amount = params.amount.saturating_sub(fee);
 
     let mut promise_id = unsafe {
@@ -264,18 +259,6 @@ fn forward_nep141_token<I: IO + Env + PromiseHandler>(mut io: I, token_id: Accou
     };
 
     io.promise_return(promise_id);
-}
-
-// Validate that calculated part of the fee isn't more than `MAX_FEE_PERCENT`.
-fn is_fee_allowed(amount: u128, fee: u128) -> bool {
-    match (fee * 100)
-        .checked_div(amount)
-        .zip((fee * 100).checked_rem(amount))
-    {
-        Some((percent, _)) if percent > MAX_FEE_PERCENT => false,
-        Some((percent, reminder)) if percent == MAX_FEE_PERCENT && reminder > 0 => false,
-        _ => true,
-    }
 }
 
 struct NoopAllocator;

--- a/tests/src/tests/mod.rs
+++ b/tests/src/tests/mod.rs
@@ -390,7 +390,7 @@ async fn test_storage_deposit_refund() {
     let balance_after_create = sandbox.balance(factory.id()).await;
     assert_eq!(
         to_near(balance_before_create - balance_after_create),
-        0.363_685 // Ⓝ
+        0.358_680 // Ⓝ
     );
 
     let sk = SecretKey::from_str("ed25519:61TF7S52FVETjLp6KMUDp1TYBEdc1km1GnHgZc67VhWfyHTCUTMjUY6mM3qML17EAHFiutjpmF4CD9wdSGtG19tR").unwrap();
@@ -405,7 +405,7 @@ async fn test_storage_deposit_refund() {
     println!("balance_after_delete: {balance_after_delete}");
     assert_eq!(
         to_near(balance_before_create - balance_after_delete),
-        0.003_722 // Ⓝ
+        0.003_716 // Ⓝ
     );
 }
 


### PR DESCRIPTION
The check is redundant since the forwarder contract receives a fee from the fee contract. The fee contract checks that the fee is within the allowed bounds. Because of that, we just can't use fee more than allowed in the forwarder contract. So the check is redundant. Closes the [issue](https://github.com/AuditOneAuditReviews/AuroraF-C-audit-review/issues/3). 