### PR TITLE
fix: use promise_create_call for calling one promise

### DIFF
--- a/forwarder/src/lib.rs
+++ b/forwarder/src/lib.rs
@@ -103,7 +103,7 @@ pub extern "C" fn calculate_fees_callback() {
     };
 
     let promise_id = unsafe {
-        let promise_id = io.promise_create_and_combine(&[PromiseCreateArgs {
+        let promise_id = io.promise_create_call(&PromiseCreateArgs {
             target_account_id: state.fees_contract_id,
             method: "calculate_fees",
             args: types::to_borsh(&FeesParams {
@@ -115,7 +115,7 @@ pub extern "C" fn calculate_fees_callback() {
             .sdk_unwrap(),
             attached_balance: ZERO_YOCTO,
             attached_gas: CALCULATE_FEES_GAS,
-        }]);
+        });
 
         io.promise_attach_callback(
             promise_id,

--- a/tests/src/tests/mod.rs
+++ b/tests/src/tests/mod.rs
@@ -390,7 +390,7 @@ async fn test_storage_deposit_refund() {
     let balance_after_create = sandbox.balance(factory.id()).await;
     assert_eq!(
         to_near(balance_before_create - balance_after_create),
-        0.358_680 // Ⓝ
+        0.358_679 // Ⓝ
     );
 
     let sk = SecretKey::from_str("ed25519:61TF7S52FVETjLp6KMUDp1TYBEdc1km1GnHgZc67VhWfyHTCUTMjUY6mM3qML17EAHFiutjpmF4CD9wdSGtG19tR").unwrap();


### PR DESCRIPTION
The PR fixes the [issue](https://github.com/AuditOneAuditReviews/AuroraF-C-audit-review/issues/6) from AuditOne.